### PR TITLE
Use Awaited type to improve pool return type

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "mri": "1.1.5",
     "prettier": "2.0.5",
     "rimraf": "3.0.2",
-    "typescript": "3.8.3",
+    "typescript": "4.5.5",
     "typescript-esm": "1.0.1"
   },
   "volta": {

--- a/src/pool.ts
+++ b/src/pool.ts
@@ -6,7 +6,7 @@ export async function pool<R, T>(
   items: Array<R>,
   iteratorFn: (item: R, items: Array<R>) => T,
   concurrency: number = cpus().length,
-): Promise<Array<T>> {
+): Promise<Array<Awaited<T>>> {
   const itemsLength: number = items.length;
   const returnable: Array<Promise<T>> = [];
   const executing: Array<Promise<T>> = [];

--- a/test/pool/basic.test.ts
+++ b/test/pool/basic.test.ts
@@ -1,6 +1,8 @@
 import * as assert from 'assert';
 import { pool } from '../../src/pool';
 
+function expectType<T>(arg: T) {}
+
 export const tests: Map<string, () => Promise<void>> = new Map([
   [
     'runs as many promises in parallel as specified by concurrency',
@@ -38,6 +40,22 @@ export const tests: Map<string, () => Promise<void>> = new Map([
     async function () {
       const timeout = () => Promise.reject();
       assert.rejects(pool([100, 500, 300, 200], timeout, 5));
+    },
+  ],
+  [
+    'returns a single Promise containing an array of results',
+    async function () {
+      const double = (item: number) =>
+        new Promise<number>((resolve) =>
+          setTimeout(() => {
+            resolve(item * 2);
+          }, item),
+        );
+
+      const items = [100, 500, 300, 200];
+      const results = await pool(items, double);
+      expectType<number[]>(results);
+      assert.deepStrictEqual(results, [200, 1000, 600, 400]);
     },
   ],
 ]);

--- a/test/pool/basic.test.ts
+++ b/test/pool/basic.test.ts
@@ -7,7 +7,7 @@ export const tests: Map<string, () => Promise<void>> = new Map([
     async function () {
       const results: Array<number> = [];
       const timeout = (item: number) =>
-        new Promise((resolve) =>
+        new Promise<void>((resolve) =>
           setTimeout(() => {
             results.push(item);
             resolve();
@@ -23,7 +23,7 @@ export const tests: Map<string, () => Promise<void>> = new Map([
     async function () {
       const results: Array<number> = [];
       const timeout = (item: number) =>
-        new Promise((resolve) =>
+        new Promise<void>((resolve) =>
           setTimeout(() => {
             results.push(item);
             resolve();

--- a/yarn.lock
+++ b/yarn.lock
@@ -460,6 +460,11 @@ typescript@3.8.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
   integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
+typescript@4.5.5:
+  version "4.5.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
+  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"


### PR DESCRIPTION
The current type of `pool` returns an array of promises whereas in reality, `pool` returns an array of the awaited values for those promises. This PR fixes the return type of `pool` using the Awaited type in TypeScript. Requires TypeScript 4.5.

Before:
<img width="436" alt="image" src="https://user-images.githubusercontent.com/459878/212264308-56b5b250-f274-423c-bf66-99b0c9296f0c.png">

After:
<img width="434" alt="image" src="https://user-images.githubusercontent.com/459878/212264453-bf8a55ee-33f9-40c5-b351-a655c5202b2c.png">

I've added a test and asserted the return type of pool using a lil `expecType` helper which will fail the TS build if something changes and breaks the return type